### PR TITLE
Refactor Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV BUILD_DEPS   make gcc musl-dev git libevent-dev expat-dev shadow autoconf fi
 ENV RUNTIME_DEPS bash util-linux coreutils findutils grep openssl ldns ldns-tools libevent expat libexecinfo coreutils drill ca-certificates
 
 RUN set -x && \
-    apk --update upgrade && apk add --no-cache $RUNTIME_DEPS $BUILD_DEPS && \
+    apk --no-cache upgrade && apk add --no-cache $RUNTIME_DEPS $BUILD_DEPS && \
     update-ca-certificates 2> /dev/null || true
 
 ENV UNBOUND_GIT_URL https://github.com/jedisct1/unbound.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,8 @@ ENV LIBSODIUM_GIT_URL https://github.com/jedisct1/libsodium.git
 RUN set -x && \
     mkdir -p /tmp/src && \
     cd /tmp/src && \
-    git clone "$LIBSODIUM_GIT_URL" && \
+    git clone --branch stable "$LIBSODIUM_GIT_URL" && \
     cd libsodium && \
-    git checkout stable && \
     env CFLAGS=-Ofast ./configure --disable-dependency-tracking && \
     make check && make install && \
     ldconfig /usr/local/lib && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV UNBOUND_GIT_REVISION 7bd08b7a9987a0780892131f8590b6e384194bbc
 RUN set -x && \
     mkdir -p /tmp/src && \
     cd /tmp/src && \
-    git clone "$UNBOUND_GIT_URL" && \
+    git clone --depth=1000 "$UNBOUND_GIT_URL" && \
     cd unbound && \
     git checkout "$UNBOUND_GIT_REVISION" && \
     groupadd _unbound && \
@@ -32,7 +32,7 @@ ENV LIBSODIUM_GIT_URL https://github.com/jedisct1/libsodium.git
 RUN set -x && \
     mkdir -p /tmp/src && \
     cd /tmp/src && \
-    git clone --branch stable "$LIBSODIUM_GIT_URL" && \
+    git clone --depth=1 --branch stable "$LIBSODIUM_GIT_URL" && \
     cd libsodium && \
     env CFLAGS=-Ofast ./configure --disable-dependency-tracking && \
     make check && make install && \
@@ -47,7 +47,7 @@ COPY queue.h /tmp
 RUN set -x && \
     mkdir -p /tmp/src && \
     cd /tmp/src && \
-    git clone --branch=${DNSCRYPT_WRAPPER_GIT_BRANCH} ${DNSCRYPT_WRAPPER_GIT_URL} && \
+    git clone --depth=1 --branch=${DNSCRYPT_WRAPPER_GIT_BRANCH} ${DNSCRYPT_WRAPPER_GIT_URL} && \
     cd dnscrypt-wrapper && \
     sed -i 's#<sys/queue.h>#"/tmp/queue.h"#' compat.h && \
     sed -i 's#HAVE_BACKTRACE#NO_BACKTRACE#' compat.h && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN set -x && \
     useradd -g _unbound -s /etc -d /dev/null _unbound && \
     ./configure --prefix=/opt/unbound --with-pthreads \
     --with-username=_unbound --with-libevent --enable-event-api && \
-    make install && \
+    make -j$(getconf _NPROCESSORS_ONLN) install && \
     mv /opt/unbound/etc/unbound/unbound.conf /opt/unbound/etc/unbound/unbound.conf.example && \
     rm -fr /opt/unbound/share/man && \
     rm -fr /tmp/* /var/tmp/*
@@ -35,7 +35,7 @@ RUN set -x && \
     git clone --depth=1 --branch stable "$LIBSODIUM_GIT_URL" && \
     cd libsodium && \
     env CFLAGS=-Ofast ./configure --disable-dependency-tracking && \
-    make check && make install && \
+    make -j$(getconf _NPROCESSORS_ONLN) check && make -j$(getconf _NPROCESSORS_ONLN) install && \
     ldconfig /usr/local/lib && \
     rm -fr /tmp/* /var/tmp/*
 
@@ -56,9 +56,9 @@ RUN set -x && \
     useradd -g _dnscrypt-wrapper -s /etc -d /opt/dnscrypt-wrapper/empty _dnscrypt-wrapper && \
     groupadd _dnscrypt-signer && \
     useradd -g _dnscrypt-signer -G _dnscrypt-wrapper -s /etc -d /dev/null _dnscrypt-signer && \
-    make configure && \
+    make -j$(getconf _NPROCESSORS_ONLN) configure && \
     env CFLAGS=-Ofast ./configure --prefix=/opt/dnscrypt-wrapper && \
-    make install && \
+    make -j$(getconf _NPROCESSORS_ONLN) install && \
     rm -fr /tmp/* /var/tmp/*
 
 RUN set -x && \


### PR DESCRIPTION
This is a refactor pull request to help reduce the image size and also the build time :tada: 

- Docker image size - before: 268MB, after: 47MB
- Docker image build time (on my 4-core PC) - before: 8 mins, after: 4 mins

Let me know what do you think ;)

(BTW, DNSCrypt is awesome! This Docker image project for DNSCrypt Server is Awesome!)