### PR TITLE
Enable Travis CI with basic Docker build testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+---
+
+dist: xenial
+
+language: minimal
+
+git:
+  depth: 5
+
+script:
+  - docker build -t dnscrypt-server-docker-ci-test .
+
+services:
+  - docker


### PR DESCRIPTION
Currently, there is no CI or other tests integrated with this repository, I'd like to help add one.

This can help verify each pull request and commit to be built successfully, which makes the contributions and changes more reliable and even easier, as those can't be built without problem will fail the CI :smile:

See an example of how the CI build would look like here: https://travis-ci.com/PeterDaveHello/dnscrypt-server-docker/ 

I picked Travis CI service because it might be the most popular choice for open source projects, let me know if you have any suggestion or other thoughts, thanks.

(Travis CI may need to be enabled manually once this PR was merged)