### PR TITLE
Adjust edns-buffer-size (DNS Flag Day 2020)

### DIFF
--- a/unbound.sh
+++ b/unbound.sh
@@ -33,7 +33,7 @@ server:
   num-threads: @THREADS@
   interface: 127.0.0.1@553
   so-reuseport: yes
-  edns-buffer-size: 1220
+  edns-buffer-size: 1232
   delay-close: 10000
   cache-min-ttl: 3600
   cache-max-ttl: 86400


### PR DESCRIPTION
[DNS Flag Day 2020](https://dnsflagday.net/2020/) recommends a message size of 1232 bytes to avoid IP fragmentation while minimizaing the use of TCP