### PR TITLE
Overwrite symlink: ( #102 )

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -175,7 +175,7 @@ start() {
         tee "${KEYS_DIR}/provider-info.txt"
 
     find /var/svc -mindepth 1 -maxdepth 1 -type d | while read -r service; do
-        ln -s "$service" "${SERVICES_DIR}/"
+        ln -s -f "$service" "${SERVICES_DIR}/"
     done
 
     exec /etc/runit/2 </dev/null >/dev/null 2>/dev/null


### PR DESCRIPTION
This resolves #102. (I actually faced the same issue.)

The issue was due to failing create a symlink when it restarts. So by overwriting it when the server restarts, it works. (Or should I check the existence of the symlink when restarts?)