### PR TITLE
Updated Kubernetes configurations and added docker-compose support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,8 @@ COPY encrypted-dns.sh /var/svc/encrypted-dns/run
 
 COPY watchdog.sh /var/svc/watchdog/run
 
+RUN ln -sf /opt/encrypted-dns/etc/keys/encrypted-dns.toml /opt/encrypted-dns/etc/encrypted-dns.toml
+
 VOLUME ["/opt/encrypted-dns/etc/keys"]
 
 EXPOSE 443/udp 443/tcp 9100/tcp

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Table of contents:
   - [TLS (including HTTPS and DoH) forwarding](#tls-including-https-and-doh-forwarding)
   - [Filtering](#filtering)
 - [Join the network](#join-the-network)
+- [Usage with Docker Compose](#usage-with-docker-compose)
 - [Usage with Kubernetes](#usage-with-kubernetes)
 - [Customizing Unbound](#customizing-unbound)
   - [Changing the Unbound configuration file](#changing-the-unbound-configuration-file)
@@ -202,14 +203,25 @@ in minutes.
 
 - Create a static IP on GCE. This will be used for the LoadBalancer.
 - Edit `kube/dnscrypt-init-job.yml`. Change `example.com` to your desired hostname
-and `192.0.2.53` to your static IP.
-- Edit `kube/dnscrypt-srv.yml` and change `loadBalancerIP` to your static IP.
+and `127.0.0.1` to your static IP.
+- Edit `kube/dnscrypt-srv.yml` and change `loadBalancerIP` to your static IP in both locations.
 - Run `kubectl create -f kube/dnscrypt-init-job.yml` to setup your keys.
 - Run `kubectl create -f kube/dnscrypt-deployment.yml` to deploy the dnscrypt server.
 - Run `kubectl create -f kube/dnscrypt-srv.yml` to expose your server to the world.
 
 To get your public key just view the logs for the `dnscrypt-init` job. The public
 IP for your server is merely the `dnscrypt` service address.
+
+# Usage with Docker Compose
+
+You can setup a server very quickly with Docker Compose.
+
+- Run `docker-compose up`
+- Ctrl-C after keys are setup.
+- Edit `docker-compose.yml` to use the start command.
+- Run `docker-compose up`
+
+Now you will have a local server running on port 5444.
 
 # Customizing Unbound
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3"
+services:
+  dnscrypt:
+    image: zquestz/dnscrypt-server:latest
+    container_name: dnscrypt
+    restart: always
+    command: "init -N example.com -E '127.0.0.1:5443'"
+    # command: "start"
+    ports:
+        - '5443:5443/udp'
+        - '5443:5443/tcp'
+    volumes:
+      - keys:/opt/encrypted-dns/etc/keys
+    environment:
+    - TZ='UTC'
+volumes:
+  keys:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ KEYS_DIR="/opt/encrypted-dns/etc/keys"
 STATE_DIR="${KEYS_DIR}/state"
 LISTS_DIR="/opt/encrypted-dns/etc/lists"
 CONF_DIR="/opt/encrypted-dns/etc"
-CONFIG_FILE="${CONF_DIR}/encrypted-dns.toml"
+CONFIG_FILE="${KEYS_DIR}/encrypted-dns.toml"
 CONFIG_FILE_TEMPLATE="${CONF_DIR}/encrypted-dns.toml.in"
 SERVICES_DIR="/etc/runit/runsvdir/svmanaged"
 

--- a/kube/dnscrypt-deployment.yml
+++ b/kube/dnscrypt-deployment.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: default
@@ -9,22 +9,30 @@ spec:
   strategy:
     type: Recreate
   replicas: 1
+  selector:
+    matchLabels:
+      service: dnscrypt
   template:
     metadata:
       labels:
         service: dnscrypt
     spec:
       containers:
-      - env:
-        image: jedisct1/dnscrypt-server
+      - image: zquestz/dnscrypt-server:latest
+        imagePullPolicy: Always
         name: dnscrypt
+        ports:
+        - containerPort: 5443
+          protocol: UDP
+        - containerPort: 5443
+          protocol: TCP
         volumeMounts:
           - name: dnscrypt-keys
             mountPath: /opt/encrypted-dns/etc/keys
         command: ["/entrypoint.sh", "start"]
         resources:
           requests:
-            memory: "1Gi"
+            memory: "64Mi"
       restartPolicy: Always
       volumes:
         - name: dnscrypt-keys

--- a/kube/dnscrypt-init-job.yml
+++ b/kube/dnscrypt-init-job.yml
@@ -9,8 +9,9 @@ spec:
     spec:
       containers:
       - name: dnscrypt-init
-        image: jedisct1/dnscrypt-server
-        command: ["/entrypoint.sh", "init", "-A", "-M", "0.0.0.0:9100", "-N", "example.com", "-E", "192.0.2.53:443"]
+        image: zquestz/dnscrypt-server:latest
+        imagePullPolicy: Always
+        command: ["/entrypoint.sh", "init", "-A", "-M", "0.0.0.0:9100", "-N", "example.com", "-E", "127.0.0.1:5443"]
         volumeMounts:
           - name: dnscrypt-keys
             mountPath: /opt/encrypted-dns/etc/keys

--- a/kube/dnscrypt-srv.yml
+++ b/kube/dnscrypt-srv.yml
@@ -3,27 +3,33 @@ kind: Service
 metadata:
   name: dnscrypt-tcp
   namespace: default
+  annotations:
+    cloud.google.com/network-tier: Standard
 spec:
   ports:
     - protocol: TCP
-      port: 443
-      targetPort: 443
+      port: 5443
+      targetPort: 5443
   selector:
     service: dnscrypt
   type: LoadBalancer
   loadBalancerIP: 0.0.0.0
+  externalTrafficPolicy: Local
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: dnscrypt-udp
   namespace: default
+  annotations:
+    cloud.google.com/network-tier: Standard
 spec:
   ports:
     - protocol: UDP
-      port: 443
-      targetPort: 443
+      port: 5443
+      targetPort: 5443
   selector:
     service: dnscrypt
   type: LoadBalancer
   loadBalancerIP: 0.0.0.0
+  externalTrafficPolicy: Local


### PR DESCRIPTION
Additions:
- Save encrypted-dns.toml on the mounted keys volume, and make sure there is a symlink pointing to it from etc.
- Added docker-compose. This works without configuration. Just run `docker-compose up`. Then change the command to start, and run it again. Keys will be persisted and it can be restarted without any issues. I used port `5443` so it doesn't conflict with other services. In my env 443 is trickier to deploy when running nginx load balancers.
- Added required annotations for GCE networking policies.

Fixes https://github.com/DNSCrypt/dnscrypt-server-docker/issues/104 https://github.com/DNSCrypt/dnscrypt-server-docker/issues/94 https://github.com/DNSCrypt/dnscrypt-server-docker/issues/101