### PR TITLE
Add authoritative zone handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ ENV UNBOUND_GIT_REVISION a8739bad76d4d179290627e989c7ef236345bda6
 
 WORKDIR /tmp
 
+# --- FOR TESTING ---
+# RUN apt-get update && apt-get install -y iproute2 less vim
+
 RUN apt-get update && apt-get install -qy --no-install-recommends $BUILD_DEPS && \
     git clone --depth=1000 "$UNBOUND_GIT_URL" && \
     cd unbound && \


### PR DESCRIPTION
Hey,

so this would address #116.

I've changed using `getopts` to `getopt` that allows for long option parameters (see the commented out lines as to why). I don't use it right now but the time may come so why not put it in ahead of time. Also I fixed a startup error.

The way it works is, when you mount the `/etc/dnscrypt-server/auth-zones` directory, it gets picked up by the startup script and generate a different configuration in terms of what interfaces to listen on, and what queries to answer to, depending on where they arrive from.

I've tested this variant on my local VM, seems to be working.

Documentation is still missing; this is just a WIP version. Add your input if you'd like, but to my taste this is already good enough to go. If nothing else, I'll add the documentation part, and then you can merge (and hopefully release ASAP).